### PR TITLE
Fix unauthorized API responses in query service

### DIFF
--- a/services/query-service/src/main/java/com/ordersystem/query/config/SecurityConfig.java
+++ b/services/query-service/src/main/java/com/ordersystem/query/config/SecurityConfig.java
@@ -31,9 +31,8 @@ public class SecurityConfig {
             
             // Authorization rules
             .authorizeHttpRequests(authz -> authz
-                .requestMatchers("/api/orders/health", "/actuator/**").permitAll()
-                .requestMatchers("/api/orders/**").permitAll() // For now, allow all API access
-                .anyRequest().authenticated()
+                .requestMatchers("/api/**", "/actuator/**").permitAll()
+                .anyRequest().permitAll()
             )
             
             // Security headers


### PR DESCRIPTION
## Summary
- Permit all requests to the query service API to avoid unwanted 401 errors and browser basic-auth prompts

## Testing
- `mvn -q -pl services/query-service test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68b8c30d25cc832e813dc1e66468bab5