### PR TITLE
fix: configure postgres datasource for render

### DIFF
--- a/services/order-query-service/src/main/resources/application-render.yml
+++ b/services/order-query-service/src/main/resources/application-render.yml
@@ -4,17 +4,17 @@ server:
 
 spring:
   datasource:
-    url: ${DATABASE_URL:jdbc:h2:mem:querydb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
-    username: ${DATABASE_USERNAME:sa}
-    password: ${DATABASE_PASSWORD:}
-    driver-class-name: ${DATABASE_DRIVER:org.h2.Driver}
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/querydb}
+    username: ${DATABASE_USERNAME:query_user}
+    password: ${DATABASE_PASSWORD:password}
+    driver-class-name: ${DATABASE_DRIVER:org.postgresql.Driver}
     hikari:
       maximum-pool-size: 10
       
   jpa:
     hibernate:
       ddl-auto: update
-    database-platform: ${HIBERNATE_DIALECT:org.hibernate.dialect.H2Dialect}
+    database-platform: ${HIBERNATE_DIALECT:org.hibernate.dialect.PostgreSQLDialect}
     show-sql: false
 
 logging:

--- a/services/order-service/src/main/java/com/ordersystem/order/config/DatabaseConfig.java
+++ b/services/order-service/src/main/java/com/ordersystem/order/config/DatabaseConfig.java
@@ -1,5 +1,8 @@
 package com.ordersystem.order.config;
 
+import java.net.URI;
+import java.net.URISyntaxException;
+
 import javax.sql.DataSource;
 
 import org.slf4j.Logger;
@@ -7,13 +10,14 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.jdbc.DataSourceBuilder;
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
 
 /**
  * Database Configuration for Render PostgreSQL
  * Handles URL format conversion from Render format to JDBC format
  */
-// @Configuration - TEMPORARILY DISABLED FOR DEBUGGING
+@Configuration
 public class DatabaseConfig {
 
     private static final Logger logger = LoggerFactory.getLogger(DatabaseConfig.class);
@@ -21,20 +25,47 @@ public class DatabaseConfig {
     @Value("${spring.datasource.url}")
     private String databaseUrl;
 
+    @Value("${spring.datasource.username:}")
+    private String username;
+
+    @Value("${spring.datasource.password:}")
+    private String password;
+
     @Bean
     @Primary
     public DataSource dataSource() {
         logger.info("🔧 Configuring PostgreSQL DataSource for Render");
 
-        // Convert Render DATABASE_URL format to JDBC format
         String jdbcUrl = databaseUrl;
-        if (databaseUrl.startsWith("postgresql://")) {
-            jdbcUrl = "jdbc:" + databaseUrl;
-            logger.info("🔄 Converted Render DATABASE_URL format: {} -> {}", databaseUrl, jdbcUrl);
+        String user = username;
+        String pass = password;
+
+        try {
+            if (databaseUrl.startsWith("postgresql://")) {
+                URI uri = new URI(databaseUrl);
+                String hostPort = uri.getHost();
+                if (uri.getPort() != -1) {
+                    hostPort += ":" + uri.getPort();
+                }
+                jdbcUrl = "jdbc:postgresql://" + hostPort + uri.getPath();
+
+                if ((user == null || user.isBlank()) && uri.getUserInfo() != null) {
+                    String[] parts = uri.getUserInfo().split(":", 2);
+                    user = parts[0];
+                    if (parts.length > 1) {
+                        pass = parts[1];
+                    }
+                }
+                logger.info("🔄 Converted Render DATABASE_URL format: {} -> {}", databaseUrl, jdbcUrl);
+            }
+        } catch (URISyntaxException e) {
+            logger.error("❌ Invalid DATABASE_URL format: {}", databaseUrl, e);
         }
 
         DataSource dataSource = DataSourceBuilder.create()
                 .url(jdbcUrl)
+                .username(user)
+                .password(pass)
                 .driverClassName("org.postgresql.Driver")
                 .build();
 

--- a/services/order-service/src/main/resources/application-render.yml
+++ b/services/order-service/src/main/resources/application-render.yml
@@ -6,17 +6,17 @@ server:
 
 spring:
   datasource:
-    url: ${DATABASE_URL:jdbc:h2:mem:orderdb;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE}
-    username: ${DATABASE_USERNAME:sa}
-    password: ${DATABASE_PASSWORD:}
-    driver-class-name: ${DATABASE_DRIVER:org.h2.Driver}
+    url: ${DATABASE_URL:jdbc:postgresql://localhost:5432/orderdb}
+    username: ${DATABASE_USERNAME:order_user}
+    password: ${DATABASE_PASSWORD:password}
+    driver-class-name: ${DATABASE_DRIVER:org.postgresql.Driver}
     hikari:
       maximum-pool-size: 10
       
   jpa:
     hibernate:
       ddl-auto: update
-    database-platform: ${HIBERNATE_DIALECT:org.hibernate.dialect.H2Dialect}
+    database-platform: ${HIBERNATE_DIALECT:org.hibernate.dialect.PostgreSQLDialect}
     show-sql: false
   
   rabbitmq:


### PR DESCRIPTION
## Summary
- ensure order and query services parse Render DATABASE_URL and configure PostgreSQL datasource
- default Render profile to PostgreSQL driver and dialect

## Testing
- `mvn -q -f services/order-service/pom.xml test` *(fails: Network is unreachable and 'parent.relativePath' points at no local POM)*
- `mvn -q -f services/order-query-service/pom.xml test` *(fails: Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68b98b9a41ac832eac0cf58e514ebe42