### PR TITLE
feat: improve order status update endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,271 +1,130 @@
-# 🛒 Sistema de Gestão de Pedidos Distribuído
+# Distributed Order System
 
-[![Deploy Status](https://img.shields.io/badge/Deploy-Production-success)](https://gestao-de-pedidos.onrender.com)
-[![Architecture](https://img.shields.io/badge/Architecture-Microservices-blue)](https://github.com)
-[![Event Sourcing](https://img.shields.io/badge/Pattern-Event%20Sourcing-orange)](https://github.com)
+Sistema de gestão de pedidos com arquitetura de microsserviços, Event Sourcing e frontend em React.
 
-> Sistema distribuído de gestão de pedidos implementado com arquitetura de microsserviços, Event Sourcing e deploy automatizado no Render.com
+## Arquitetura
 
-## 🚀 Demo em Produção
+- **Backend:** Spring Boot (Java 17)
+- **Frontend:** React + Vite
+- **Event Bus:** RabbitMQ
+- **Cache/Event Store:** Redis
+- **Banco de Dados:** PostgreSQL
+- **Containerização:** Docker / Docker Compose
 
-**URL de Produção**: [https://gestao-de-pedidos.onrender.com](https://gestao-de-pedidos.onrender.com)
+### Serviços
 
-## ✨ Características
+| Serviço | Porta | Responsabilidade |
+|--------|-------|------------------|
+| Order Service | 8081 | CRUD de pedidos e publicação de eventos |
+| Payment Service | 8082 | Processamento de pagamentos |
+| Inventory Service | 8083 | Controle de estoque |
+| Query Service | 8084 | Projeções e consultas (CQRS) |
 
-- **Arquitetura de Microsserviços**: 4 serviços independentes com responsabilidades bem definidas
-- **Event Sourcing**: Armazenamento completo do histórico de eventos com Redis Streams
-- **Deploy Automatizado**: CI/CD completo no Render.com com GitHub Actions
-- **Interface Moderna**: Dashboard responsivo com design glassmorphism
-- **Alta Disponibilidade**: Nginx com fallbacks e health checks automatizados
-- **Otimização de Memória**: JVM tuning para deploy em containers de 512MB
+## Endpoints principais
 
-## 🏗️ Arquitetura
+### Order Service (`/api/orders`)
 
-### Microsserviços
+| Método | Caminho | Descrição |
+|--------|--------|-----------|
+| `POST` | `/api/orders` | Criar pedido |
+| `GET` | `/api/orders` | Listar pedidos |
+| `GET` | `/api/orders/{id}` | Obter pedido por ID |
+| `PUT` | `/api/orders/{id}/status` | Atualizar status do pedido |
+| `GET` | `/api/orders/customer/{customerId}` | Pedidos de um cliente |
+| `GET` | `/api/orders/{id}/events` | Eventos de um pedido (Event Sourcing) |
+| `GET` | `/api/orders/{id}/rebuild` | Reconstruir pedido a partir dos eventos |
+| `GET` | `/api/orders/health` | Health check |
 
-- **Order Service** (Port 8081): Gerenciamento de pedidos
-- **Payment Service** (Port 8082): Processamento de pagamentos  
-- **Inventory Service** (Port 8083): Controle de estoque
-- **Query Service** (Port 8084): Agregação de dados e consultas
+### Payment Service (`/api/payments`)
 
-### Stack Tecnológica
+- `GET /api/payments`
+- `GET /api/payments/{id}`
+- `POST /api/payments/{id}/retry`
 
-- **Backend**: Java 21 + Spring Boot 3.4
-- **Event Sourcing**: Redis Streams
-- **Frontend**: HTML5 + CSS3 + Vanilla JavaScript
-- **Proxy**: Nginx com balanceamento
-- **Deploy**: Render.com com CI/CD
-- **Containerização**: Docker multi-stage
+### Inventory Service (`/api/inventory`)
 
-### Render.com Services
+- `GET /api/inventory`
 
-1. **Web Service** (gestao-de-pedidos)
-   - Frontend + Nginx + Query Service
-   - Endpoint público com health checks
-   - Memória: 512MB
+### Query Service (`/api/orders`)
 
-2. **Background Workers**
-   - Order Service (background)
-   - Payment Service (background) 
-   - Inventory Service (background)
+- `GET /api/orders` – consultas paginadas
+- `GET /api/orders/{id}` – leitura otimizada
+- `GET /api/orders/customer/{customerId}` – pedidos por cliente
 
-3. **Redis Service**
-   - Event streaming
-   - Cache distribuído
+## Setup local
 
-## 🛠️ Tecnologias
-
-### Backend
-- Java 17
-- Spring Boot 3.1.5
-- Spring Data JPA
-- Spring AMQP
-- PostgreSQL 15
-- RabbitMQ
-- Redis
-- Resilience4j
-- Docker
-
-### Frontend
-- React 18
-- TypeScript
-- Vite
-- shadcn/ui
-- TanStack Query
-- React Router
-- Tailwind CSS
-- Lucide Icons
-
-## 🚀 Como Executar
-
-### Pré-requisitos
-
-- Docker e Docker Compose
-- Java 17 (para desenvolvimento local)
-- Node.js 18+ (para desenvolvimento do frontend)
-- Maven 3.6+
-
-### Execução Completa com Docker
-
-1. **Clone o repositório**
-   ```bash
-   git clone <repository-url>
-   cd order-management-system
-   ```
-
-2. **Build e execute todos os serviços**
-   ```bash
-   # Build da biblioteca compartilhada
-   cd shared-events
-   mvn clean install
-   cd ..
-
-   # Iniciar todo o sistema
-   docker-compose up --build
-   ```
-
-3. **Acesse as aplicações**
-   - **Frontend**: http://localhost:3000
-   - **API Gateway**: http://localhost:8080
-   - **RabbitMQ Management**: http://localhost:15672 (guest/guest)
-
-### Desenvolvimento Local
-
-#### Backend
-
-1. **Iniciar infraestrutura**
-   ```bash
-   docker-compose up order-db query-db rabbitmq redis
-   ```
-
-2. **Build da biblioteca compartilhada**
-   ```bash
-   cd shared-events
-   mvn clean install
-   cd ..
-   ```
-
-3. **Executar serviços individualmente**
-   ```bash
-   # Order Service
-   cd services/order-service
-   mvn spring-boot:run
-
-   # Payment Service
-   cd services/payment-service
-   mvn spring-boot:run
-
-   # Inventory Service
-   cd services/inventory-service
-   mvn spring-boot:run
-
-   # Query Service
-   cd services/order-query-service
-   mvn spring-boot:run
-   ```
-
-#### Frontend
-
-1. **Instalar dependências**
-   ```bash
-   cd frontend
-   npm install
-   ```
-
-2. **Executar em modo desenvolvimento**
-   ```bash
-   npm run dev
-   ```
-
-## 📊 Endpoints da API
-
-### Order Service (8081)
-- `GET /api/orders` - Listar pedidos
-- `POST /api/orders` - Criar pedido
-- `GET /api/orders/{id}` - Obter pedido específico
-- `DELETE /api/orders/{id}` - Cancelar pedido
-- `POST /api/orders/{id}/reserve-inventory` - Reservar estoque
-
-### Payment Service (8082)
-- `GET /api/payments` - Listar pagamentos
-- `GET /api/payments/{id}` - Obter pagamento específico
-- `POST /api/payments/{id}/retry` - Retentar pagamento
-
-### Inventory Service (8083)
-- `GET /api/inventory` - Listar itens do estoque
-
-### Query Service (8084)
-- `GET /api/dashboard/metrics` - Métricas do dashboard
-- `GET /api/orders` - Consultas otimizadas de pedidos
-
-## 🔧 Configuração
-
-### Variáveis de Ambiente
-
-#### Serviços Backend
-```env
-DATABASE_URL=jdbc:postgresql://localhost:5432/order_db
-DATABASE_USERNAME=postgres
-DATABASE_PASSWORD=password
-RABBITMQ_HOST=localhost
-RABBITMQ_PORT=5672
-RABBITMQ_USERNAME=guest
-RABBITMQ_PASSWORD=guest
-REDIS_HOST=localhost
-REDIS_PORT=6379
-```
-
-#### Frontend
-```env
-VITE_API_URL=http://localhost:8080
-VITE_WS_URL=ws://localhost:8080/ws
-```
-
-## 🧪 Testes
-
-### Backend
 ```bash
-# Executar todos os testes
-mvn clean test
+# build biblioteca compartilhada
+mvn -q -pl shared-events clean install
 
-# Testes de um serviço específico
+# subir infraestrutura
+docker-compose up order-db query-db rabbitmq redis
+
+# iniciar um serviço
 cd services/order-service
-mvn test
+mvn spring-boot:run
 ```
 
-### Frontend
+Frontend:
+
 ```bash
 cd frontend
-npm run test
+npm install
+npm run dev
 ```
 
-## 📦 Deploy
+## CI/CD
 
-### Railway.app
+Workflows GitHub Actions:
+- **build.yml** – build e testes
+- **security.yml** – scan de segurança
+- **docker.yml** – imagem Docker
+- **deploy-render.yml** – deploy automático no Render
 
-1. **Conecte o repositório ao Railway**
-2. **Configure as variáveis de ambiente**
-3. **Deploy automático será acionado**
+Render usa a branch `main` e um container com `PORT=80` exposta no `Dockerfile` principal.
 
-### Docker Production
+## Variáveis de ambiente
+
+| Nome | Descrição |
+|------|-----------|
+| `DATABASE_URL` | JDBC do Postgres |
+| `DATABASE_USERNAME` | Usuário do banco |
+| `DATABASE_PASSWORD` | Senha do banco |
+| `RABBITMQ_HOST` | Host do RabbitMQ |
+| `RABBITMQ_PORT` | Porta do RabbitMQ |
+| `REDIS_HOST` | Host do Redis |
+| `REDIS_PORT` | Porta do Redis |
+
+## Testes
 
 ```bash
-# Build para produção
-docker-compose -f docker-compose.prod.yml up --build
+mvn -pl services/order-service test
 ```
 
-## 🔍 Monitoramento
+## Deploy
 
-### Health Checks
-- Order Service: http://localhost:8081/api/orders/health
-- Payment Service: http://localhost:8082/api/payments/health
-- Inventory Service: http://localhost:8083/api/inventory/health
-- Query Service: http://localhost:8084/api/orders/health
+- Commits na branch configurada disparam o deploy automático no Render.
+- Rollback: redeploy de commit anterior via painel do Render.
 
-### Logs
+## Troubleshooting
+
+| Problema | Solução |
+|----------|---------|
+| Erro de build Maven | verifique dependências e versão do JDK |
+| Frontend não inicia | execute `npm install` e cheque `.env` |
+| Container não sobe | `docker-compose logs` para detalhes |
+| 404 em `PUT /api/orders/{id}/status` | verifique se o `orderId` existe e se o serviço Order Service está acessível |
+
+## Exemplos de uso (curl)
+
 ```bash
-# Ver logs de todos os serviços
-docker-compose logs -f
+# criar pedido
+curl -X POST http://localhost:8081/api/orders \
+  -H 'Content-Type: application/json' \
+  -d '{"customerId":"C1","totalAmount":100}'
 
-# Logs de um serviço específico
-docker-compose logs -f order-service
+# atualizar status
+curl -X PUT http://localhost:8081/api/orders/ID/status \
+  -H 'Content-Type: application/json' \
+  -d '{"status":"PAID"}'
 ```
-
-## 🤝 Contribuição
-
-1. Fork o projeto
-2. Crie uma branch para sua feature (`git checkout -b feature/AmazingFeature`)
-3. Commit suas mudanças (`git commit -m 'Add some AmazingFeature'`)
-4. Push para a branch (`git push origin feature/AmazingFeature`)
-5. Abra um Pull Request
-
-## 📝 Licença
-
-Este projeto está sob a licença MIT. Veja o arquivo [LICENSE](LICENSE) para mais detalhes.
-
-## 🆘 Suporte
-
-Para suporte e dúvidas:
-- Abra uma issue no GitHub
-- Consulte a documentação técnica em `/docs`
-- Verifique os logs dos serviços para troubleshooting

--- a/services/order-service/src/main/java/com/ordersystem/order/controller/OrderController.java
+++ b/services/order-service/src/main/java/com/ordersystem/order/controller/OrderController.java
@@ -23,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 import com.ordersystem.order.model.Order;
 import com.ordersystem.order.model.OrderEvent;
 import com.ordersystem.order.service.OrderService;
+import com.ordersystem.order.exception.OrderNotFoundException;
 
 @RestController
 @RequestMapping("/api/orders")
@@ -233,6 +234,15 @@ public class OrderController {
                     "correlationId", correlationId);
 
             return ResponseEntity.ok(response);
+        } catch (OrderNotFoundException e) {
+            logger.warn("⚠️ Order not found for status update: orderId={}, correlationId={}", id, correlationId);
+
+            Map<String, Object> response = Map.of(
+                    "success", false,
+                    "message", e.getMessage(),
+                    "orderId", id,
+                    "correlationId", correlationId);
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).body(response);
 
         } catch (RuntimeException e) {
             logger.error(

--- a/services/order-service/src/main/java/com/ordersystem/order/exception/OrderNotFoundException.java
+++ b/services/order-service/src/main/java/com/ordersystem/order/exception/OrderNotFoundException.java
@@ -1,0 +1,10 @@
+package com.ordersystem.order.exception;
+
+/**
+ * Exception thrown when an order cannot be found.
+ */
+public class OrderNotFoundException extends RuntimeException {
+    public OrderNotFoundException(String orderId) {
+        super("Order not found: " + orderId);
+    }
+}

--- a/services/order-service/src/main/java/com/ordersystem/order/service/OrderService.java
+++ b/services/order-service/src/main/java/com/ordersystem/order/service/OrderService.java
@@ -20,6 +20,7 @@ import com.ordersystem.order.model.OrderEvent;
 import com.ordersystem.order.model.OrderStatus;
 import com.ordersystem.order.repository.OrderEventRepository;
 import com.ordersystem.order.repository.OrderRepository;
+import com.ordersystem.order.exception.OrderNotFoundException;
 import com.ordersystem.shared.events.OrderCreatedEvent;
 import com.ordersystem.shared.events.OrderStatusUpdatedEvent;
 
@@ -146,7 +147,7 @@ public class OrderService {
 
                         logger.error("❌ Order not found for status update: orderId={}, correlationId={}",
                                         orderId, correlationId);
-                        throw new RuntimeException("Order not found: " + orderId);
+                        throw new OrderNotFoundException(orderId);
 
                 } catch (Exception e) {
                         logger.error("❌ Order status update failed: orderId={}, status={}, error={}, correlationId={}",

--- a/services/order-service/src/test/java/com/ordersystem/order/controller/OrderStatusIntegrationTest.java
+++ b/services/order-service/src/test/java/com/ordersystem/order/controller/OrderStatusIntegrationTest.java
@@ -1,0 +1,64 @@
+package com.ordersystem.order.controller;
+
+import com.ordersystem.order.model.Order;
+import com.ordersystem.order.repository.OrderRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+class OrderStatusIntegrationTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private OrderRepository orderRepository;
+
+    @BeforeEach
+    void setup() {
+        orderRepository.deleteAll();
+    }
+
+    @Test
+    void updateStatusReturns200() throws Exception {
+        Order order = new Order("customer-1", 100.0);
+        order = orderRepository.save(order);
+
+        mockMvc.perform(put("/api/orders/" + order.getId() + "/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"PAID\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.newStatus").value("PAID"));
+    }
+
+    @Test
+    void updateStatusWithInvalidStatusReturns400() throws Exception {
+        Order order = new Order("customer-1", 100.0);
+        order = orderRepository.save(order);
+
+        mockMvc.perform(put("/api/orders/" + order.getId() + "/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"INVALID\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void updateStatusForMissingOrderReturns404() throws Exception {
+        mockMvc.perform(put("/api/orders/non-existent-id/status")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"PAID\"}"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("Order not found: non-existent-id"));
+    }
+}

--- a/services/order-service/src/test/resources/application-test.properties
+++ b/services/order-service/src/test/resources/application-test.properties
@@ -1,0 +1,6 @@
+spring.datasource.url=jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1
+spring.datasource.driverClassName=org.h2.Driver
+spring.datasource.username=sa
+spring.datasource.password=
+spring.jpa.hibernate.ddl-auto=create-drop
+spring.jpa.show-sql=false


### PR DESCRIPTION
## Summary
- add `OrderNotFoundException` and return 404 for missing orders
- document and test `PUT /api/orders/{id}/status`
- rewrite README with developer-focused instructions

## Testing
- `mvn -pl services/order-service test` *(fails: Cannot resolve Spring Boot parent POM; network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bda782d9c0832ea4a19d2979a6d1e4