### PR TITLE
[Fix] APIs `/api` + Actuator + Docker Bind + Docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,7 +118,6 @@ test-*.sh
 setup-*.sh
 quick-*.sh
 monitor-*.sh
-scripts/
 
 # Frontend build artifacts
 frontend/dist/

--- a/README.md
+++ b/README.md
@@ -132,3 +132,33 @@ curl -X PATCH http://localhost:8081/api/orders/ID/status \
   -H 'Content-Type: application/json' \
   -d '{"status":"PAID"}'
 ```
+
+## API Endpoints
+
+Todas as rotas REST são expostas com o prefixo `/api`:
+
+| Método | Caminho | Descrição |
+|-------|--------|-----------|
+| `GET` | `/api/orders` | Lista pedidos |
+| `POST` | `/api/orders` | Cria pedido |
+| `PUT` | `/api/orders/{id}/status` | Atualiza status |
+
+## Health check
+
+O estado da aplicação pode ser verificado em:
+
+```bash
+curl -i http://localhost:8080/actuator/health
+```
+
+## Smoke tests
+
+Execute uma verificação rápida com:
+
+```bash
+scripts/smoke.sh
+```
+
+## Deploy no Render
+
+O Render define a porta através da variável `PORT`. O container já usa `java -Dserver.port=$PORT -Dserver.address=0.0.0.0` e expõe o Actuator em `/actuator/health`.

--- a/ops/nginx.conf
+++ b/ops/nginx.conf
@@ -5,7 +5,7 @@ http {
   default_type  application/octet-stream;
   sendfile on;
   server {
-    listen 80;
+    listen @@PORT@@;
     server_name _;
 
     root /usr/share/nginx/html;

--- a/ops/start.sh
+++ b/ops/start.sh
@@ -2,7 +2,10 @@
 set -euo pipefail
 
 # Start backend in background
-java ${JAVA_OPTS:-} -jar /app/app.jar &
+PORT=${PORT:-8080}
+
+# Start backend on fixed port 8080
+java -Dserver.port=8080 -Dserver.address=0.0.0.0 ${JAVA_OPTS:-} -jar /app/app.jar &
 BACK_PID=$!
 
 # Wait for backend to be healthy (up to 60s)
@@ -12,6 +15,9 @@ until curl -fsS http://127.0.0.1:8080/actuator/health >/dev/null || [ $ATTEMPTS 
   ATTEMPTS=$((ATTEMPTS-1))
   sleep 2
 done
+
+# Configure Nginx to listen on the provided PORT
+sed -i "s/@@PORT@@/${PORT}/g" /etc/nginx/nginx.conf
 
 # Start Nginx in foreground
 exec nginx -g 'daemon off;'

--- a/scripts/smoke.sh
+++ b/scripts/smoke.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+BASE_URL=${1:-http://localhost:8080}
+
+echo "Checking health..."
+curl -i "$BASE_URL/actuator/health"
+
+echo "Checking orders..."
+curl -i "$BASE_URL/api/orders"

--- a/unified-order-system/Dockerfile
+++ b/unified-order-system/Dockerfile
@@ -41,4 +41,4 @@ HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
   CMD curl -f http://localhost:8080/actuator/health || exit 1
 
 # Run application
-ENTRYPOINT ["java", "-Dspring.profiles.active=render", "-Xms256m", "-Xmx512m", "-XX:+UseG1GC", "-XX:MaxGCPauseMillis=200", "-XX:+UseContainerSupport", "-Djava.security.egd=file:/dev/./urandom", "-jar", "app.jar"]
+ENTRYPOINT ["sh", "-c", "java -Dspring.profiles.active=${SPRING_PROFILES_ACTIVE:-render} -Dserver.port=${PORT:-8080} -Dserver.address=0.0.0.0 -Xms256m -Xmx512m -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -XX:+UseContainerSupport -Djava.security.egd=file:/dev/./urandom -jar app.jar"]

--- a/unified-order-system/src/main/java/com/ordersystem/unified/config/EndpointLoggingConfig.java
+++ b/unified-order-system/src/main/java/com/ordersystem/unified/config/EndpointLoggingConfig.java
@@ -1,0 +1,19 @@
+package com.ordersystem.unified.config;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping;
+
+@Configuration
+public class EndpointLoggingConfig {
+    private static final Logger logger = LoggerFactory.getLogger(EndpointLoggingConfig.class);
+
+    @Bean
+    public ApplicationRunner logEndpoints(RequestMappingHandlerMapping mapping) {
+        return args -> mapping.getHandlerMethods().forEach((info, method) ->
+                logger.info("Mapped {} -> {}", info, method));
+    }
+}

--- a/unified-order-system/src/main/java/com/ordersystem/unified/config/WebConfig.java
+++ b/unified-order-system/src/main/java/com/ordersystem/unified/config/WebConfig.java
@@ -8,6 +8,8 @@ import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 import java.util.List;
@@ -31,6 +33,20 @@ public class WebConfig implements WebMvcConfigurer {
     @Override
     public void configureMessageConverters(List<HttpMessageConverter<?>> converters) {
         converters.add(new MappingJackson2HttpMessageConverter(objectMapper()));
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        registry.addResourceHandler("/**")
+                .addResourceLocations("classpath:/static/", "classpath:/public/");
+    }
+
+    @Override
+    public void addViewControllers(ViewControllerRegistry registry) {
+        registry.addViewController("/{spring:[^.]*}")
+                .setViewName("forward:/index.html");
+        registry.addViewController("/**/{spring:[^.]*}")
+                .setViewName("forward:/index.html");
     }
 
     @Bean

--- a/unified-order-system/src/main/java/com/ordersystem/unified/health/HealthController.java
+++ b/unified-order-system/src/main/java/com/ordersystem/unified/health/HealthController.java
@@ -24,6 +24,7 @@ import java.util.Map;
  * Comprehensive Health Controller with service dependency monitoring
  */
 @RestController
+@RequestMapping("/api/health")
 @Tag(name = "Health Check", description = "Comprehensive system health monitoring")
 public class HealthController {
     
@@ -40,18 +41,8 @@ public class HealthController {
     
     @Autowired
     private DataSource dataSource;
-    
-    @GetMapping("/health")
-    @Operation(summary = "Simple health check", description = "Simple health endpoint for Render")
-    public ResponseEntity<Map<String, Object>> simpleHealthCheck() {
-        Map<String, Object> health = new HashMap<>();
-        health.put("status", "UP");
-        health.put("service", "unified-order-system");
-        health.put("timestamp", LocalDateTime.now());
-        return ResponseEntity.ok(health);
-    }
-    
-    @GetMapping("/api/health")
+
+    @GetMapping
     @Operation(summary = "System health check", description = "Returns the overall health status of the system with service dependencies")
     public ResponseEntity<Map<String, Object>> healthCheck() {
         logger.debug("Comprehensive health check requested");

--- a/unified-order-system/src/main/resources/application.yml
+++ b/unified-order-system/src/main/resources/application.yml
@@ -22,8 +22,6 @@ spring:
 
 server:
   port: 8080
-  servlet:
-    context-path: /
   error:
     include-message: always
     include-binding-errors: always
@@ -31,6 +29,7 @@ server:
 management:
   endpoints:
     web:
+      base-path: /actuator
       exposure:
         include: health,info,metrics,prometheus
   endpoint:


### PR DESCRIPTION
## Summary
- prefix health controller under `/api/health`
- remove servlet context-path and expose actuator on `/actuator`
- log registered routes at startup
- bind Spring Boot to `$PORT` on `0.0.0.0`
- prevent SPA from catching `/api/**`
- standardize JSON error responses
- add smoke test helper and update docs
- configure nginx to listen on the platform port and proxy to backend
- simplify SPA fallback routing to avoid invalid path pattern
- fix invalid escape sequences in SPA routing

## Testing
- `mvn -q test` *(fails: Network is unreachable)*
- `curl -i http://localhost:8080/actuator/health` *(fails: Couldn't connect to server)*
- `scripts/smoke.sh` *(fails: Couldn't connect to server)*

------
https://chatgpt.com/codex/tasks/task_e_68bdfd8d8df8832e895024f4282846fc